### PR TITLE
NUI-670 Environment variable flag to disable metrics entirely for unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ You MUST call `activationFinished()` to stop the agent when you are done sending
 metrics.activationFinished();
 ```
 
+To disable all sending of metrics to New Relic (for example in unit tests), set this environment variable:
+
+```
+OPENWHISK_NEWRELIC_DISABLE_METRICS=true
+```
+
 ### Instrumentation
 
 Supported instrumentation:
@@ -85,7 +91,7 @@ exports.main = NewRelic.instrument(main);
 To disable all instrumentation (for example in unit tests), set this environment variable:
 
 ```
-OPENWHISK_NEWRELIC_DISABLE_METRICS=true
+OPENWHISK_NEWRELIC_DISABLE_ALL_INSTRUMENTATION=true
 ```
 
 ### Action Timeout

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ exports.main = NewRelic.instrument(main);
 To disable all instrumentation (for example in unit tests), set this environment variable:
 
 ```
-OPENWHISK_NEWRELIC_DISABLE_ALL_INSTRUMENTATION=true
+OPENWHISK_NEWRELIC_DISABLE_METRICS=true
 ```
 
 ### Action Timeout

--- a/lib/newrelic.js
+++ b/lib/newrelic.js
@@ -67,32 +67,36 @@ class NewRelic {
      * @param {object} defaultMetrics default metrics to include in every New Relic event
      */
     constructor(options, defaultMetrics={}) {
+        const OPENWHISK_NEWRELIC_DISABLE_METRICS = process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS || false;
+
         this.defaultMetrics = Object.assign(Metrics.openwhisk(), defaultMetrics);
 
         this.canSendMetrics = false;
-        if (!options ||
-            isBlankString(options.newRelicEventsURL) ||
-            isBlankString(options.newRelicApiKey)
-        ) {
-            console.error('Missing NewRelic events Api Key or URL. Metrics disabled.');
 
-        } else {
-            sendQueue.start(options.newRelicEventsURL, options.newRelicApiKey, options.sendIntervalMs);
+        if (OPENWHISK_NEWRELIC_DISABLE_METRICS !== true) {
 
-            // track this object per activation for global http metrics
-            if (activationVars && activationVars.active) {
-                activationVars.set(CLS_KEY_NEWRELIC, this);
+            if (!options ||
+                isBlankString(options.newRelicEventsURL) ||
+                isBlankString(options.newRelicApiKey)
+            ) {
+                console.error('Missing NewRelic events Api Key or URL. Metrics disabled.');
+            } else {
+                sendQueue.start(options.newRelicEventsURL, options.newRelicApiKey, options.sendIntervalMs);
+
+                // track this object per activation for global http metrics
+                if (activationVars && activationVars.active) {
+                    activationVars.set(CLS_KEY_NEWRELIC, this);
+                }
+
+                if (options.actionTimeoutMetricsCb && typeof options.actionTimeoutMetricsCb !== 'function') {
+                    console.error('Action timeout is not a proper function.');
+                    delete options.actionTimeoutMetricsCb;
+                }
+                if (!options.disableActionTimeout && !process.env.DISABLE_ACTION_TIMEOUT_METRIC ) {
+                    this.actionTimeoutHandlerId = sendMetricsOnActionTimeout(this, options.actionTimeoutMetricsCb);
+                }
+                this.canSendMetrics = true;
             }
-
-            if (options.actionTimeoutMetricsCb && typeof options.actionTimeoutMetricsCb !== 'function') {
-                console.error('Action timeout is not a proper function.');
-                delete options.actionTimeoutMetricsCb;
-            }
-            if (!options.disableActionTimeout && !process.env.DISABLE_ACTION_TIMEOUT_METRIC ) {
-                this.actionTimeoutHandlerId = sendMetricsOnActionTimeout(this, options.actionTimeoutMetricsCb);
-            }
-
-            this.canSendMetrics = true;
         }
     }
 

--- a/lib/newrelic.js
+++ b/lib/newrelic.js
@@ -24,10 +24,10 @@ governing permissions and limitations under the License.
 "use strict";
 
 const Metrics = require('./metrics');
-const sendQueue = require("./queue");
+const sendQueue = require('./queue');
 
 const httpClientProbe = require('./probe/http-client');
-const cls = require("cls-hooked");
+const cls = require('cls-hooked');
 
 const CLS_NAMESPACE = "openwhisk-newrelic";
 const CLS_KEY_NEWRELIC = "NewRelic";
@@ -71,7 +71,7 @@ class NewRelic {
         this.defaultMetrics = Object.assign(Metrics.openwhisk(), defaultMetrics);
         this.canSendMetrics = false;
 
-        if (process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS === `true`) {
+        if (process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS === 'true') {
             console.error('Sending of New Relic Metrics have been disabled.');
 
         } else if (!options ||
@@ -122,7 +122,7 @@ class NewRelic {
      * Call this when the action activation finishes successfully.
      */
     async activationFinished() {
-        // action finished succesfully, there will be no timeout
+        // action finished successfully, there will be no timeout
         clearTimeout(this.actionTimeoutHandlerId);
     }
 

--- a/lib/newrelic.js
+++ b/lib/newrelic.js
@@ -67,36 +67,34 @@ class NewRelic {
      * @param {object} defaultMetrics default metrics to include in every New Relic event
      */
     constructor(options, defaultMetrics={}) {
-        const OPENWHISK_NEWRELIC_DISABLE_METRICS = process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS || false;
 
         this.defaultMetrics = Object.assign(Metrics.openwhisk(), defaultMetrics);
-
         this.canSendMetrics = false;
 
-        if (OPENWHISK_NEWRELIC_DISABLE_METRICS !== true) {
+        if (process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS === `true`) {
+            console.error('Sending of New Relic Metrics have been disabled.');
 
-            if (!options ||
-                isBlankString(options.newRelicEventsURL) ||
-                isBlankString(options.newRelicApiKey)
-            ) {
-                console.error('Missing NewRelic events Api Key or URL. Metrics disabled.');
-            } else {
-                sendQueue.start(options.newRelicEventsURL, options.newRelicApiKey, options.sendIntervalMs);
+        } else if (!options ||
+            isBlankString(options.newRelicEventsURL) ||
+            isBlankString(options.newRelicApiKey)
+        ) {
+            console.error('Missing NewRelic events Api Key or URL. Metrics disabled.');
+        } else {
+            sendQueue.start(options.newRelicEventsURL, options.newRelicApiKey, options.sendIntervalMs);
 
-                // track this object per activation for global http metrics
-                if (activationVars && activationVars.active) {
-                    activationVars.set(CLS_KEY_NEWRELIC, this);
-                }
-
-                if (options.actionTimeoutMetricsCb && typeof options.actionTimeoutMetricsCb !== 'function') {
-                    console.error('Action timeout is not a proper function.');
-                    delete options.actionTimeoutMetricsCb;
-                }
-                if (!options.disableActionTimeout && !process.env.DISABLE_ACTION_TIMEOUT_METRIC ) {
-                    this.actionTimeoutHandlerId = sendMetricsOnActionTimeout(this, options.actionTimeoutMetricsCb);
-                }
-                this.canSendMetrics = true;
+            // track this object per activation for global http metrics
+            if (activationVars && activationVars.active) {
+                activationVars.set(CLS_KEY_NEWRELIC, this);
             }
+
+            if (options.actionTimeoutMetricsCb && typeof options.actionTimeoutMetricsCb !== 'function') {
+                console.error('Action timeout is not a proper function.');
+                delete options.actionTimeoutMetricsCb;
+            }
+            if (!options.disableActionTimeout && !process.env.DISABLE_ACTION_TIMEOUT_METRIC ) {
+                this.actionTimeoutHandlerId = sendMetricsOnActionTimeout(this, options.actionTimeoutMetricsCb);
+            }
+            this.canSendMetrics = true;
         }
     }
 

--- a/lib/newrelic.js
+++ b/lib/newrelic.js
@@ -79,6 +79,7 @@ class NewRelic {
             isBlankString(options.newRelicApiKey)
         ) {
             console.error('Missing NewRelic events Api Key or URL. Metrics disabled.');
+
         } else {
             sendQueue.start(options.newRelicEventsURL, options.newRelicApiKey, options.sendIntervalMs);
 
@@ -91,6 +92,7 @@ class NewRelic {
                 console.error('Action timeout is not a proper function.');
                 delete options.actionTimeoutMetricsCb;
             }
+
             if (!options.disableActionTimeout && !process.env.DISABLE_ACTION_TIMEOUT_METRIC ) {
                 this.actionTimeoutHandlerId = sendMetricsOnActionTimeout(this, options.actionTimeoutMetricsCb);
             }

--- a/test/newrelic.test.js
+++ b/test/newrelic.test.js
@@ -135,7 +135,6 @@ describe("NewRelic", function() {
             await metrics.send();
         });
 
-
         it("constructor should not throw error if OPENWHISK_NEWRELIC_DISABLE_METRICS=true and no API key", async function () {
             process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS = true;
             const metrics = new NewRelic();

--- a/test/newrelic.test.js
+++ b/test/newrelic.test.js
@@ -68,6 +68,7 @@ describe("NewRelic", function() {
         delete process.env.__OW_NAMESPACE;
         delete process.env.__OW_ACTIVATION_ID;
         delete process.env.__OW_DEADLINE;
+        delete process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS;
 
         MetricsTestHelper.afterEachTest();
     });
@@ -130,6 +131,35 @@ describe("NewRelic", function() {
             };
 
             const metrics = new NewRelic(params);
+            assert.ok(metrics);
+            await metrics.send();
+        });
+
+
+        it("constructor should not throw error if OPENWHISK_NEWRELIC_DISABLE_METRICS=true and no API key", async function () {
+            process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS = true;
+            const metrics = new NewRelic();
+            assert.ok(metrics);
+            await metrics.send();
+        });
+
+        it("constructor should not throw error if OPENWHISK_NEWRELIC_DISABLE_METRICS=true and API Key is provided", async function () {
+            process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS = true;
+            const metrics = new NewRelic(FAKE_PARAMS);
+            assert.ok(metrics);
+            await metrics.send();
+        });
+
+        it("constructor should not throw error if OPENWHISK_NEWRELIC_DISABLE_METRICS=false and no API key", async function () {
+            process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS = false;
+            const metrics = new NewRelic();
+            assert.ok(metrics);
+            await metrics.send();
+        });
+
+        it("constructor should not throw error if OPENWHISK_NEWRELIC_DISABLE_METRICS=false and API key is provided", async function () {
+            process.env.OPENWHISK_NEWRELIC_DISABLE_METRICS = false;
+            const metrics = new NewRelic(FAKE_PARAMS);
             assert.ok(metrics);
             await metrics.send();
         });


### PR DESCRIPTION
## Description

Added environment variable to disable sending New Relic Metrics
[NUI-670 Environment variable flag to disable metrics entirely for unit tests](https://jira.corp.adobe.com/browse/NUI-670)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
