### PR TITLE
README: remove metrics attributes that are not set by this library

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,9 +153,6 @@ Sent for all metrics.
 | `package`         | string           | OpenWhisk package name of the action that sent the event.  |
 | `actionName`      | string           | OpenWhisk action name (without package) of the action that sent the event. |
 | `activationId`    | string           | OpenWhisk activation id of the action that sent the event. |
-| `appName`         | string           | Name of the invoking IO console integration (API key label) |
-| `clientId`        | string           | API key = IMS client id of the invoking technical account/integration/client. |
-| `sourceName`      | string           | Filename of the source. |
 | `cloud`           | string           | Cloud in which the activation ran, e.g. `aws` or `azure` (`__OW_CLOUD`). |
 | `region`          | string           | Region in which the activation ran, e.g. `us-east-1` (`__OW_REGION`). |
 | `transactionId`   | string           | OpenWhisk transaction id (`__OW_TRANSACTION_ID`). |


### PR DESCRIPTION
## Description

These attributes aren't actually set by this library - they were accidentally copy/pasted in here:

- `appName`
- `clientId`
- `sourceName`

They are set in another library: https://github.com/adobe/asset-compute-commons/blob/500e048bd3b13c6ba4ed2ee6eed1f40545821068/lib/metrics.js#L48-L49

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Documentation change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
