### PR TITLE
Update ubuntu versions used for github actions

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     strategy:
       matrix:
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v2
     - run: npx @adobe/sizewatcher
   semantic-release:
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     needs: [build]
     if: ${{  !contains(github.event.head_commit.message, '[ci skip]') && github.ref == 'refs/heads/master' }}
     steps:


### PR DESCRIPTION
## Description

Currently actions are set with ubuntu-16-04 as the OS version which was retired and not working anymore.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
