### PR TITLE
increasing error metric string max length

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Reference: <https://docs.newrelic.com/docs/insights/insights-data-sources/custom
   * 255 attributes
   * 255 characters in the attribute name
   * 100 character length limit of individual string values (NR supports 4k but this library will truncate long strings automatically and add an ellipsis.)
-  * 1500 character length for error metric strings
+  * 1500 character length for error metric strings by default, or configurable by setting the `NEW_RELIC_ERROR_METRIC_MAX_STRING_LENGTH` environment variable
   * 100,000 HTTP POST requests/min, 429 status after, counter reset of 1 minute window
 
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Reference: <https://docs.newrelic.com/docs/insights/insights-data-sources/custom
   * 255 attributes
   * 255 characters in the attribute name
   * 100 character length limit of individual string values (NR supports 4k but this library will truncate long strings automatically and add an ellipsis.)
+  * 1500 character length for error metric strings
   * 100,000 HTTP POST requests/min, 429 status after, counter reset of 1 minute window
 
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -130,7 +130,7 @@ function toMetricsObject(obj) {
         for (const [key,value] of obj) {
             if (typeof key === 'string') {
                 // increase max string length for error metrics
-                if (ERROR_METRIC_NAMES.indexOf(key) > -1) {
+                if (ERROR_METRIC_NAMES.includes(key)) {
                     result[key] = truncateString(value, DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH);
                 } else {
                     result[key] = truncateString(value);
@@ -181,7 +181,7 @@ function flatten(metrics, parentKey) {
         const type = typeof value;
         if (type === "string") {
             // increase max string length for error metrics
-            if (ERROR_METRIC_NAMES.indexOf(key) > -1) {
+            if (ERROR_METRIC_NAMES.includes(key)) {
                 result[`${parentKey}${key}`] = truncateString(value, DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH);
             } else {
                 result[`${parentKey}${key}`] = truncateString(value);

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -18,6 +18,12 @@ const fs = require('fs');
 
 const DEFAULT_METRIC_TIMEOUT_MS = 60000; // default openwhisk action timeout
 const DEFAULT_MAX_STRING_LENGTH = 100;
+const DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH = 1500;
+const ERROR_METRIC_NAMES = [
+    'message',
+    'errorMessage',
+    'error'
+];
 
 /**
  * Retrieve timestamp in milliseconds since Unix epoch for
@@ -123,7 +129,12 @@ function toMetricsObject(obj) {
         const result = {};
         for (const [key,value] of obj) {
             if (typeof key === 'string') {
-                result[key] = truncateString(value);
+                // increase max string length for error metrics
+                if (ERROR_METRIC_NAMES.indexOf(key) > -1) {
+                    result[key] = truncateString(value, DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH);
+                } else {
+                    result[key] = truncateString(value);
+                }
             }
         }
         return result;
@@ -169,7 +180,12 @@ function flatten(metrics, parentKey) {
     for (const [ key, value ] of Object.entries(metrics)) {
         const type = typeof value;
         if (type === "string") {
-            result[`${parentKey}${key}`] = truncateString(value);
+            // increase max string length for error metrics
+            if (ERROR_METRIC_NAMES.indexOf(key) > -1) {
+                result[`${parentKey}${key}`] = truncateString(value, DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH);
+            } else {
+                result[`${parentKey}${key}`] = truncateString(value);
+            }
         } else if (type === "number") {
             result[`${parentKey}${key}`] = value;
         } else if (type === "boolean") {

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -18,7 +18,7 @@ const fs = require('fs');
 
 const DEFAULT_METRIC_TIMEOUT_MS = 60000; // default openwhisk action timeout
 const DEFAULT_MAX_STRING_LENGTH = 100;
-const DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH = 1500;
+const DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH = process.env.NEW_RELIC_ERROR_METRIC_MAX_STRING_LENGTH || 1500;
 const ERROR_METRIC_NAMES = [
     'message',
     'errorMessage',

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -210,6 +210,41 @@ describe("metrics.js", () => {
             assert(flatten.value.length === maxLength);
         });
 
+        it("truncates long error metric strings to configured length", () => {
+            const maxLength = Metrics.__get__("DEFAULT_MAX_STRING_LENGTH");
+            const maxErrorLength = Metrics.__get__("DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH");
+            const longValue = "!".repeat(maxErrorLength + maxLength + 100);
+            const flatten = Metrics.flatten({
+                message: longValue,
+                errorMessage: longValue,
+                error: longValue,
+                nonErrorMessage: longValue,
+            });
+            // applies error metric max length
+            assert(flatten.message.length === maxErrorLength);
+            assert(flatten.errorMessage.length === maxErrorLength);
+            assert(flatten.error.length === maxErrorLength);
+            // applies normal string max length
+            assert(flatten.nonErrorMessage.length === maxLength);
+        });
+
+        it("truncates error metrics on nested object to configured length", () => {
+            const maxLength = Metrics.__get__("DEFAULT_MAX_STRING_LENGTH");
+            const maxErrorLength = Metrics.__get__("DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH");
+            const longValue = "!".repeat(maxErrorLength + maxLength + 100);
+
+            const nested = {
+                errorMessage: longValue,
+                nonErrorMessage: longValue
+            };
+            const flatten = Metrics.flatten({ nested });
+
+            // applies error metric max length
+            assert(flatten.nested_errorMessage.length === maxErrorLength);
+            // applies normal string max length
+            assert(flatten.nested_nonErrorMessage.length === maxLength);
+        });
+
         it("boolean", () => {
             const flatten = Metrics.flatten({ value1: true, value2: false });
             assert.deepStrictEqual(flatten, { value1: 1, value2: 0 });

--- a/test/metrics.test.js
+++ b/test/metrics.test.js
@@ -238,11 +238,24 @@ describe("metrics.js", () => {
                 nonErrorMessage: longValue
             };
             const flatten = Metrics.flatten({ nested });
-
             // applies error metric max length
             assert(flatten.nested_errorMessage.length === maxErrorLength);
             // applies normal string max length
             assert(flatten.nested_nonErrorMessage.length === maxLength);
+        });
+
+        it("truncates error metrics to length set in env variable", () => {
+            process.env.NEW_RELIC_ERROR_METRIC_MAX_STRING_LENGTH = 1200;
+            // rewire Metrics after env variable set
+            const MetricsWithEnvVar = rewire("../lib/metrics");
+            const maxErrorLength = MetricsWithEnvVar.__get__("DEFAULT_ERROR_METRIC_MAX_STRING_LENGTH");
+            const longValue = "!".repeat(maxErrorLength + 100);
+
+            const flatten = MetricsWithEnvVar.flatten({
+                message: longValue
+            });
+            // applies error metric max length
+            assert(flatten.message.length === 1200);
         });
 
         it("boolean", () => {


### PR DESCRIPTION
## Description

- Adjusts max string length for error messages (metrics with names `message`, `errorMessage`, and `error`) to `1500`; existing string limit of `100` was not modified for other metrics
- This is based on a sample of 25 metrics logged in `error` and `clientError` where the majority of errors were around 600-900 characters in length, and ffmpeg errors were as large as 1200 characters

Fixes # ASSETS-9702

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
